### PR TITLE
Fix mutornadomon to work with psutil 3.1.1

### DIFF
--- a/mutornadomon/monitor.py
+++ b/mutornadomon/monitor.py
@@ -144,13 +144,17 @@ class MuTornadoMon(object):
     def metrics(self):
         """Return the current metrics. Resets max gauges."""
         me = psutil.Process(os.getpid())
-        meminfo = me.get_memory_info()
+
+        # Starting with 2.0.0, get_* methods are deprecated.
+        # At 3.1.1 they are dropped.
         if psutil.version_info < (2, 0, 0):
+            meminfo = me.get_memory_info()
             cpuinfo = me.get_cpu_times()
             create_time = me.create_time
             num_threads = me.get_num_threads()
             num_fds = me.get_num_fds()
         else:
+            meminfo = me.memory_info()
             cpuinfo = me.cpu_times()
             create_time = me.create_time()
             num_threads = me.num_threads()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tornado>=3.0
-psutil>=1.2.0,<3.0
+psutil>=1.2.0
 mock>=0.9
 six


### PR DESCRIPTION
version 3.1.1 of psutil introduced this breaking change:
https://github.com/giampaolo/psutil/commit/ab211934af0acf99091e4cd534fc5bbe7fd3b233

That drops the `get_*` methods. These were renamed in 2.0 with the `get_*` methods left as
deprecated, so still use them for <2.0.
https://github.com/giampaolo/psutil/blob/ab211934af0acf99091e4cd534fc5bbe7fd3b233/HISTORY.rst#200---2014-03-10