### PR TITLE
Add publish callback support and decouple from web/HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 [![Build Status](https://travis-ci.org/uber/mutornadomon.png)](https://travis-ci.org/uber/mutornadomon)
 
+# mutornadomon
+
 **µtornadomon** is a library designed to be used with Tornado web applications. It adds an endpoint
 (`/mutornadomon`) to HTTP servers which outputs application statistics for use with standard metric
 collectors.
 
-In general, to use it you do something like
+# Usage
+
+The monitor is initialized using `mutornadomon.config.initialize_mutornadomon`.
+
+## Exposing an HTTP endpoint
+
+If you only pass a tornado web application, it will include request/response statistics,
+and expose an HTTP endpoint for polling by external processes:
 
 ```
 from mutornadomon.config import initialize_mutornadomon
@@ -13,10 +22,10 @@ import signal
 [...]
 
 application = tornado.web.Application(...)
-collector = initialize_mutornadomon(application)
+monitor = initialize_mutornadomon(application)
 
 def shut_down(*args):
-    collector.stop()
+    monitor.stop()
     some_other_application_stop_function()
     tornado.ioloop.IOLoop.current().stop()
 
@@ -24,7 +33,47 @@ for sig in (signal.SIGQUIT, signal.SIGINT, signal.SIGTERM):
     signal.signal(sig, shut_down)
 ```
 
+This will add a `/mutornadomon` endpoint to the web application.
+
+Here is an example request to that endpoint:
+
+```
+$ curl http://localhost:8080/mutornadomon
+{"process": {"uptime": 38.98995113372803, "num_fds": 8, "meminfo": {"rss_bytes": 14020608, "vsz_bytes": 2530562048}, "cpu": {"num_threads": 1, "system_time": 0.049356776, "user_time": 0.182635456}}, "max_gauges": {"ioloop_pending_callbacks": 0, "ioloop_handlers": 2, "ioloop_excess_callback_latency": 0.0006290912628173773}, "min_gauges": {"ioloop_pending_callbacks": 0, "ioloop_handlers": 2, "ioloop_excess_callback_latency": -0.004179096221923834}, "gauges": {"ioloop_pending_callbacks": 0, "ioloop_handlers": 2, "ioloop_excess_callback_latency": 0.0006290912628173773}, "counters": {"callbacks": 388, "requests": 6, "localhost_requests": 6, "private_requests": 6}}
+```
+
 If you want to add your own metrics, you can do so by calling the `.kv()` or
-`.count()` methods on the collector object at any time.
+`.count()` methods on the monitor object at any time.
 
 The HTTP endpoint is restricted to only respond to request from loopback.
+
+## Providing a publishing callback
+
+Alternatively, instead of polling the HTTP interface, you can pass in a `publisher` callback:
+
+```
+import pprint
+
+def publisher(metrics):
+    pprint.pprint(metrics)
+
+monitor = initialize_mutornadomon(application, publisher=publisher)
+```
+
+By default, this will call the publisher callback every 10 seconds.
+To override this pass the `publish_interval` parameter (in miliseconds).
+
+## Monitoring non-web applications
+
+If you don't pass an application object, other stats can still be collected:
+
+```
+import pprint
+
+def publisher(metrics):
+    pprint.pprint(metrics)
+
+monitor = initialize_mutornadomon(publisher=publisher)
+```
+
+This only works with the publisher callback interface.

--- a/mutornadomon/collectors/__init__.py
+++ b/mutornadomon/collectors/__init__.py
@@ -1,0 +1,1 @@
+from mutornadomon.collectors.web import WebCollector  # noqa

--- a/mutornadomon/collectors/web.py
+++ b/mutornadomon/collectors/web.py
@@ -1,0 +1,29 @@
+from mutornadomon import net
+
+
+class NullTransform(object):
+
+    def transform_first_chunk(self, status_code, headers, chunk, *args, **kwargs):
+        return status_code, headers, chunk
+
+    def transform_chunk(self, chunk, *args, **kwargs):
+        return chunk
+
+
+class WebCollector(object):
+    """Collects stats from a tornado.web.application.Application"""
+
+    def __init__(self, monitor, tornado_app):
+        self.monitor = monitor
+        self.tornado_app = tornado_app
+
+    def start(self):
+        self.tornado_app.add_transform(self._request)
+
+    def _request(self, request):
+        self.monitor.count('requests', 1)
+        if net.is_local_address(request.remote_ip):
+            self.monitor.count('localhost_requests', 1)
+        if net.is_private_address(request.remote_ip):
+            self.monitor.count('private_requests', 1)
+        return NullTransform()

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -1,18 +1,31 @@
 from __future__ import absolute_import
 
-import mutornadomon
+from mutornadomon import MuTornadoMon
+from mutornadomon.external_interfaces.publish import PublishExternalInterface
+from mutornadomon.external_interfaces.http_endpoints import HTTPEndpointExternalInterface
+from mutornadomon.collectors.web import WebCollector
 
 
-def initialize_mutornadomon(tornado_app, **monitor_config):
+def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=None,
+                            host_limit=None, request_filter=None, **monitor_config):
     """Register mutornadomon to get Tornado request metrics"""
+    if not publisher and not tornado_app:
+        raise ValueError('Must pass at least one of `publisher` and `tornado_app`')
+
+    if publisher:
+        external_interface = PublishExternalInterface(publisher,
+                                                      publish_interval=publish_interval)
+    else:
+        external_interface = HTTPEndpointExternalInterface(tornado_app,
+                                                           request_filter=request_filter,
+                                                           host_limit=host_limit)
+
     # Start collecting metrics and register endpoint with app
-    monitor = mutornadomon.MuTornadoMon(**monitor_config)
-    monitor.register_application(tornado_app)
+    monitor = MuTornadoMon(external_interface, **monitor_config)
     monitor.start()
-    return monitor
 
+    if tornado_app:
+        web_collector = WebCollector(monitor, tornado_app)
+        web_collector.start()
 
-def instrument_ioloop(io_loop, publisher, **monitor_config):
-    monitor = mutornadomon.MuTornadoMon(io_loop=io_loop, publisher=publisher, **monitor_config)
-    monitor.start()
     return monitor

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -10,3 +10,13 @@ def initialize_mutornadomon(tornado_app, **monitor_config):
     monitor.register_application(tornado_app)
     monitor.start()
     return monitor
+
+
+def instrument_ioloop(
+        interval=10,
+        io_loop=None,
+        **monitor_config
+    ):
+    monitor = mutornadomon.MuTornadoMon(**monitor_config)
+    monitor.instrument_ioloop(io_loop)
+    monitor.start()

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -12,11 +12,7 @@ def initialize_mutornadomon(tornado_app, **monitor_config):
     return monitor
 
 
-def instrument_ioloop(
-        interval=10,
-        io_loop=None,
-        **monitor_config
-    ):
-    monitor = mutornadomon.MuTornadoMon(**monitor_config)
-    monitor.instrument_ioloop(io_loop)
+def instrument_ioloop(io_loop, publisher, **monitor_config):
+    monitor = mutornadomon.MuTornadoMon(io_loop=io_loop, publisher=publisher, **monitor_config)
     monitor.start()
+    return monitor

--- a/mutornadomon/external_interfaces/__init__.py
+++ b/mutornadomon/external_interfaces/__init__.py
@@ -1,0 +1,2 @@
+from mutornadomon.external_interfaces.http_endpoints import HTTPEndpointExternalInterface  # noqa
+from mutornadomon.external_interfaces.publish import PublishExternalInterface  # noqa

--- a/mutornadomon/external_interfaces/http_endpoints.py
+++ b/mutornadomon/external_interfaces/http_endpoints.py
@@ -1,0 +1,53 @@
+import tornado
+
+from mutornadomon import net
+
+
+def LOCALHOST(request):
+    if not net.is_local_address(request.remote_ip):
+        return False
+    xff = request.headers.get('X-Forwarded-For', None)
+    if not xff or net.is_local_address(xff):
+        return True
+    return False
+
+
+class StatusHandler(tornado.web.RequestHandler):
+
+    def initialize(self, monitor, request_filter):
+        self.monitor = monitor
+        self.request_filter = request_filter
+
+    def prepare(self):
+        if not self.request_filter(self.request):
+            self.send_error(403)
+
+    def get(self):
+        self.write(self.monitor.metrics)
+
+
+class HTTPEndpointExternalInterface(object):
+    """External interface that exposes HTTP endpoints for polling by an external process."""
+
+    def __init__(self, app, host_limit=None, request_filter=None):
+        self.app = app
+        if request_filter is None:
+            self.request_filter = LOCALHOST
+        else:
+            self.request_filter = request_filter
+
+        if host_limit is None:
+            self._host_limit = r'.*'
+        else:
+            self._host_limit = host_limit
+
+    def start(self, monitor):
+        self.app.add_handlers(self._host_limit, [
+            (r'/mutornadomon', StatusHandler, {
+                'monitor': monitor,
+                'request_filter': self.request_filter
+            })
+        ])
+
+    def stop(self):
+        pass

--- a/mutornadomon/external_interfaces/publish.py
+++ b/mutornadomon/external_interfaces/publish.py
@@ -1,0 +1,37 @@
+import logging
+
+import tornado
+
+
+class PublishExternalInterface(object):
+    """External interface that delegates metrics publishing to a publisher callback."""
+    PUBLISH_FREQUENCY = 10 * 1000  # ms
+
+    logger = logging.getLogger('mutornadomon')
+
+    def __init__(self, publisher, publish_interval=None):
+        self.publisher = publisher
+        self.publish_callback = None
+        self.publish_interval = publish_interval or self.PUBLISH_FREQUENCY
+
+    def start(self, monitor):
+        if self.publish_callback is not None:
+            raise ValueError('Publish callback already started')
+
+        self.publish_callback = tornado.ioloop.PeriodicCallback(
+            lambda: self._publish(monitor),
+            self.publish_interval,
+            monitor.io_loop,
+        )
+        self.publish_callback.start()
+
+    def stop(self):
+        if self.publish_callback is not None:
+            self.publish_callback.stop()
+            self.publish_callback = None
+
+    def _publish(self, monitor):
+        try:
+            self.publisher(monitor.metrics)
+        except:
+            self.logger.exception('Metrics publisher raised an exception')

--- a/mutornadomon/monitor.py
+++ b/mutornadomon/monitor.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import collections
-import logging
 import time
 
 import tornado.ioloop
@@ -10,54 +9,17 @@ import os
 import psutil
 import mock
 
-from . import net
-
 CALLBACK_FREQUENCY = 100  # ms
-PUBLISH_FREQUENCY = 10 * 1000  # ms
-
-
-def LOCALHOST(request):
-    if not net.is_local_address(request.remote_ip):
-        return False
-    xff = request.headers.get('X-Forwarded-For', None)
-    if not xff or net.is_local_address(xff):
-        return True
-    return False
-
-
-class StatusHandler(tornado.web.RequestHandler):
-    def initialize(self, monitor, request_filter):
-        self.monitor = monitor
-        self.request_filter = request_filter
-
-    def prepare(self):
-        if not self.request_filter(self.request):
-            self.send_error(403)
-
-    def get(self):
-        self.write(self.monitor.metrics)
-
-
-class NullTransform(object):
-    def transform_first_chunk(self, status_code, headers, chunk, *args, **kwargs):
-        return status_code, headers, chunk
-
-    def transform_chunk(self, chunk, *args, **kwargs):
-        return chunk
 
 
 class MuTornadoMon(object):
 
-    logger = logging.getLogger('mutornadomon')
-
     def __init__(
         self,
-        host_limit=r'.*',
-        request_filter=LOCALHOST,
+        external_interface,
+        collectors=None,
         io_loop=None,
-        publisher=None,
         measure_interval=CALLBACK_FREQUENCY,
-        publish_interval=PUBLISH_FREQUENCY,
     ):
         """Constructor for MuTornadoMon monitor
 
@@ -70,16 +32,15 @@ class MuTornadoMon(object):
 
         :param io_loop: IOLoop to run on if not using the standard singleton.
 
-        :param publisher: A callable that takes the current metrics dictionary as an arugment and
-        takes care of publishing them.
+        :param external_interface:
 
         :param measure_interval: The interval at which the latency of the ioloop is measured.
-
-        :param publish_interval: The interval at which the publisher will be called periodically.
         """
+        if collectors is None:
+            self.collectors = []
+        else:
+            self.collectors = collectors
         self.io_loop = io_loop or tornado.ioloop.IOLoop.current()
-        self._host_limit = host_limit
-        self.request_filter = request_filter
 
         self.measure_callback = tornado.ioloop.PeriodicCallback(
             self._cb,
@@ -87,16 +48,7 @@ class MuTornadoMon(object):
             self.io_loop,
         )
 
-        self.publisher = publisher
-
-        if callable(publisher):
-            self.publish_callback = tornado.ioloop.PeriodicCallback(
-                self._publish,
-                publish_interval,
-                self.io_loop,
-            )
-        else:
-            self.publish_callback = None
+        self.external_interface = external_interface
 
         self._ioloop_exception_patch = None
         self._monkey_patch_ioloop_exceptions()
@@ -106,12 +58,6 @@ class MuTornadoMon(object):
             self._COUNTERS = collections.defaultdict(lambda: 0)
         self._GAUGES = {}
         self._reset_ephemeral()
-
-    def _publish(self):
-        try:
-            self.publisher(self.metrics)
-        except:
-            self.logger.exception('Metrics publisher raised an exception')
 
     def _monkey_patch_ioloop_exceptions(self):
         if self._ioloop_exception_patch is not None:
@@ -160,18 +106,19 @@ class MuTornadoMon(object):
             self._MIN_GAUGES[stat] = value
 
     def start(self):
+        for collector in self.collectors:
+            collector.start(self)
+        self.external_interface.start(self)
         self._last_cb_time = time.time()
         self.measure_callback.start()
-        if self.publish_callback:
-            self.publish_callback.start()
 
     def stop(self):
+        self.external_interface.stop()
+        for collector in self.collectors:
+            collector.stop()
         if self.measure_callback is not None:
             self.measure_callback.stop()
             self.measure_callback = None
-        if self.publish_callback is not None:
-            self.publish_callback.stop()
-            self.publish_callback = None
         if self._ioloop_exception_patch is not None:
             self._ioloop_exception_patch.stop()
             self._ioloop_exception_patch = None
@@ -228,24 +175,3 @@ class MuTornadoMon(object):
         }
         self._reset_ephemeral()
         return rv
-
-    def register_application(self, app):
-        """Register an instance of tornado.web.Application to expose statistics on."""
-        app.add_handlers(self._host_limit, [
-            (r'/mutornadomon', StatusHandler, {
-                'monitor': self,
-                'request_filter': self.request_filter
-            })
-        ])
-        self._instrument_app(app)
-
-    def _request(self, request):
-        self.count('requests', 1)
-        if net.is_local_address(request.remote_ip):
-            self.count('localhost_requests', 1)
-        if net.is_private_address(request.remote_ip):
-            self.count('private_requests', 1)
-        return NullTransform()
-
-    def _instrument_app(self, app):
-        app.add_transform(self._request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 tornado>=3.0
 psutil>=1.2.0
-mock>=0.9
+mock>=0.9,<=1.0.1
 six

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,7 @@ import mock
 import psutil
 from tornado.ioloop import IOLoop
 import tornado.testing
-from mutornadomon.config import initialize_mutornadomon, instrument_ioloop
+from mutornadomon.config import initialize_mutornadomon
 
 from six import b
 
@@ -58,9 +58,9 @@ class TestPublisher(tornado.testing.AsyncTestCase):
     def test_publisher_called(self, mock_num_threads):
         publisher = mock.Mock(return_value=None)
 
-        monitor = instrument_ioloop(IOLoop.current(), publisher)
+        monitor = initialize_mutornadomon(io_loop=IOLoop.current(), publisher=publisher)
         monitor.count('my_counter', 2)
-        monitor._publish()
+        monitor.external_interface._publish(monitor)
 
         self.assertTrue(publisher.called_once())
         metrics = publisher.call_args_list[0][0][0]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,10 @@
 import json
 
+import mock
+import psutil
+from tornado.ioloop import IOLoop
 import tornado.testing
-from mutornadomon.config import initialize_mutornadomon
+from mutornadomon.config import initialize_mutornadomon, instrument_ioloop
 
 from six import b
 
@@ -26,7 +29,8 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
         super(TestBasic, self).tearDown()
         self.monitor.stop()
 
-    def test_endpoint(self):
+    @mock.patch.object(psutil.Process, 'num_threads', autospec=True, return_value=5)
+    def test_endpoint(self, mock_num_threads):
         resp = self.fetch('/')
         self.assertEqual(resp.body, b('HELO 127.0.0.1'))
         resp = self.fetch('/mutornadomon')
@@ -36,7 +40,7 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
             resp['counters'],
             {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}
         )
-        self.assertEqual(resp['process']['cpu']['num_threads'], 1)
+        self.assertEqual(resp['process']['cpu']['num_threads'], 5)
         assert resp['process']['cpu']['system_time'] < 1.0
 
     def test_endpoint_xff(self):
@@ -46,3 +50,24 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
     def test_endpoint_not_public(self):
         resp = self.fetch('/mutornadomon', headers={'X-Forwarded-For': '8.8.8.8'})
         self.assertEqual(resp.code, 403)
+
+
+class TestPublisher(tornado.testing.AsyncTestCase):
+
+    @mock.patch.object(psutil.Process, 'num_threads', autospec=True, return_value=5)
+    def test_publisher_called(self, mock_num_threads):
+        publisher = mock.Mock(return_value=None)
+
+        monitor = instrument_ioloop(IOLoop.current(), publisher)
+        monitor.count('my_counter', 2)
+        monitor._publish()
+
+        self.assertTrue(publisher.called_once())
+        metrics = publisher.call_args_list[0][0][0]
+
+        self.assertEqual(
+            metrics['counters'],
+            {'my_counter': 2}
+        )
+        self.assertEqual(metrics['process']['cpu']['num_threads'], 5)
+        assert metrics['process']['cpu']['system_time'] < 1.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -107,5 +107,5 @@ class TestInitializeMutornadomon(unittest.TestCase):
     @mock.patch('tornado.ioloop.PeriodicCallback')
     def test_initialize_mutornadomon_raises_when_no_publisher_and_no_app(self, periodic_callback_mock):
         """Test instrument_ioloop() setups monitoring and creates a PeriodicCallback"""
-        with self.assertRaises(ValueError):
-            initialize_mutornadomon(io_loop=tornado.ioloop.IOLoop.current())
+        self.assertRaises(ValueError, initialize_mutornadomon,
+                          io_loop=tornado.ioloop.IOLoop.current())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
     @mock.patch('tornado.ioloop.PeriodicCallback')
     def test_instrument_ioloop(self, periodic_callback_mock):
-        """Test initialize_mutornadomon() setups monitoring and shutdown"""
+        """Test instrument_ioloop() setups monitoring and creates a PeriodicCallback"""
 
         def publisher():
             pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,38 +6,106 @@ import mutornadomon
 import tornado.ioloop
 import unittest
 
-from mutornadomon.config import initialize_mutornadomon, instrument_ioloop
+from mutornadomon.config import initialize_mutornadomon
+from mutornadomon.external_interfaces import (HTTPEndpointExternalInterface,
+                                              PublishExternalInterface)
 
 
 class TestInitializeMutornadomon(unittest.TestCase):
 
-    @mock.patch('mutornadomon.config.mutornadomon')
-    def test_initialize_mutornadmon(self, mutornadomon_mock):
-        """Test initialize_mutornadomon() setups monitoring and shutdown"""
-        result = initialize_mutornadomon(sentinel.application,
-                                         host_limit='test')
-        monitor_inst = mutornadomon_mock.MuTornadoMon.return_value
+    @mock.patch('mutornadomon.config.MuTornadoMon')
+    @mock.patch('mutornadomon.config.WebCollector')
+    def test_initialize_mutornadmon(self, web_collector_mock, mutornadomon_mock):
+        """Test initialize_mutornadomon() sets up HTTP endpoints interface"""
+        app = sentinel.application,
+        result = initialize_mutornadomon(app, host_limit='test')
+        monitor_inst = mutornadomon_mock.return_value
 
         # initialize_mutornadomon() should return the monitor instance
         self.assertEqual(result, monitor_inst)
 
-        # MuTornadoMon was created with monitor config values
-        mutornadomon_mock.MuTornadoMon.assert_called_once_with(
-            host_limit='test')
+        mutornadomon_mock.assert_called_once()
+        web_collector_mock.assert_called_once_with(monitor_inst, app)
 
-        # Monitor instance was registered with tornado application
-        monitor_inst.register_application.assert_called_once_with(
-            sentinel.application)
+        # MuTornadoMon was created with monitor config values
+        arg_list = mutornadomon_mock.call_args_list
+
+        self.assertEquals(len(arg_list), 1)
+        args, kwargs = arg_list[0]
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], HTTPEndpointExternalInterface)
+
+        self.assertEqual(kwargs, {})
+
+    @mock.patch('mutornadomon.config.MuTornadoMon')
+    @mock.patch('mutornadomon.config.WebCollector')
+    def test_initialize_mutornadmon_passes_publisher(self, web_collector_mock, mutornadomon_mock):
+        """Test initialize_mutornadomon() sets up publishing interface"""
+
+        def publisher(monitor):
+            pass
+
+        app = sentinel.application
+        result = initialize_mutornadomon(app,
+                                         publisher=publisher,
+                                         host_limit='test')
+        monitor_inst = mutornadomon_mock.return_value
+
+        # initialize_mutornadomon() should return the monitor instance
+        self.assertEqual(result, monitor_inst)
+
+        web_collector_mock.assert_called_once_with(monitor_inst, app)
+
+        mutornadomon_mock.assert_called_once()
+        arg_list = mutornadomon_mock.call_args_list
+
+        args, kwargs = arg_list[0]
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], PublishExternalInterface)
+
+        self.assertEqual(kwargs, {})
+
+    @mock.patch('mutornadomon.config.MuTornadoMon')
+    def test_initialize_mutornadmon_works_with_publisher_and_no_app(self, mutornadomon_mock):
+        """Test initialize_mutornadomon() works with publisher, but no web app passed"""
+
+        def publisher(monitor):
+            pass
+
+        result = initialize_mutornadomon(publisher=publisher)
+        monitor_inst = mutornadomon_mock.return_value
+
+        # initialize_mutornadomon() should return the monitor instance
+        self.assertEqual(result, monitor_inst)
+
+        mutornadomon_mock.assert_called_once()
+
+        # MuTornadoMon was created with monitor config values
+        arg_list = mutornadomon_mock.call_args_list
+
+        self.assertEquals(len(arg_list), 1)
+        args, kwargs = arg_list[0]
+        self.assertEqual(len(args), 1)
+        self.assertIsInstance(args[0], PublishExternalInterface)
+
+        # No collectors are passed
+        self.assertEqual(kwargs.keys(), [])
 
     @mock.patch('tornado.ioloop.PeriodicCallback')
-    def test_instrument_ioloop(self, periodic_callback_mock):
+    def test_publisher_initializer(self, periodic_callback_mock):
         """Test instrument_ioloop() setups monitoring and creates a PeriodicCallback"""
 
         def publisher():
             pass
 
-        result = instrument_ioloop(tornado.ioloop.IOLoop.current(), publisher=publisher)
+        result = initialize_mutornadomon(io_loop=tornado.ioloop.IOLoop.current(), publisher=publisher)
 
         periodic_callback_mock.assert_called_once()
 
         self.assertTrue(isinstance(result, mutornadomon.MuTornadoMon))
+
+    @mock.patch('tornado.ioloop.PeriodicCallback')
+    def test_initialize_mutornadomon_raises_when_no_publisher_and_no_app(self, periodic_callback_mock):
+        """Test instrument_ioloop() setups monitoring and creates a PeriodicCallback"""
+        with self.assertRaises(ValueError):
+            initialize_mutornadomon(io_loop=tornado.ioloop.IOLoop.current())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 
 import mock
 from mock import sentinel
+import mutornadomon
+import tornado.ioloop
 import unittest
 
-from mutornadomon.config import initialize_mutornadomon
+from mutornadomon.config import initialize_mutornadomon, instrument_ioloop
 
 
 class TestInitializeMutornadomon(unittest.TestCase):
@@ -26,3 +28,16 @@ class TestInitializeMutornadomon(unittest.TestCase):
         # Monitor instance was registered with tornado application
         monitor_inst.register_application.assert_called_once_with(
             sentinel.application)
+
+    @mock.patch('tornado.ioloop.PeriodicCallback')
+    def test_instrument_ioloop(self, periodic_callback_mock):
+        """Test initialize_mutornadomon() setups monitoring and shutdown"""
+
+        def publisher():
+            pass
+
+        result = instrument_ioloop(tornado.ioloop.IOLoop.current(), publisher=publisher)
+
+        periodic_callback_mock.assert_called_once()
+
+        self.assertTrue(isinstance(result, mutornadomon.MuTornadoMon))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,7 +33,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEquals(len(arg_list), 1)
         args, kwargs = arg_list[0]
         self.assertEqual(len(args), 1)
-        self.assertIsInstance(args[0], HTTPEndpointExternalInterface)
+        self.assertTrue(isinstance(args[0], HTTPEndpointExternalInterface))
 
         self.assertEqual(kwargs, {})
 
@@ -61,7 +61,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
         args, kwargs = arg_list[0]
         self.assertEqual(len(args), 1)
-        self.assertIsInstance(args[0], PublishExternalInterface)
+        self.assertTrue(isinstance(args[0], PublishExternalInterface))
 
         self.assertEqual(kwargs, {})
 
@@ -86,7 +86,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEquals(len(arg_list), 1)
         args, kwargs = arg_list[0]
         self.assertEqual(len(args), 1)
-        self.assertIsInstance(args[0], PublishExternalInterface)
+        self.assertTrue(isinstance(args[0], PublishExternalInterface))
 
         # No collectors are passed
         self.assertEqual(kwargs.keys(), [])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,7 +89,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertTrue(isinstance(args[0], PublishExternalInterface))
 
         # No collectors are passed
-        self.assertEqual(kwargs.keys(), [])
+        self.assertEqual(kwargs, {})
 
     @mock.patch('tornado.ioloop.PeriodicCallback')
     def test_publisher_initializer(self, periodic_callback_mock):


### PR DESCRIPTION
@blampe @abachm 
Instead of simply exposing metrics through HTTP and polling those endpoints, we can now register a
callback that publishes stats periodically (for example, to statsd).