### PR TITLE
Add ioloop utilization metric

### DIFF
--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -5,9 +5,8 @@ from functools import wraps
 class UtilizationCollector(object):
     """Collects stats for overall callback durations"""
 
-    def __init__(self, monitor, flush_interval):
+    def __init__(self, monitor):
         self.monitor = monitor
-        self.flush_interval = flush_interval or 10000
 
     def start(self):
         self.original_add_callback = self.monitor.io_loop.add_callback

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -4,15 +4,15 @@ import time
 class UtilizationCollector(object):
 
     def __init__(self, monitor):
-        self.last_time = time.time()
+        self.last_start_time = time.time()
         self.monitor = monitor
 
     def __enter__(self):
         now = time.time()
-        self.last_time = now
+        self.last_start_time = now
 
     def __exit__(self, *args, **kwargs):
-        duration = (time.time() - self.last_time)
-        self.last_time = time.time()
+        duration = (time.time() - self.last_start_time)
+        self.last_start_time = time.time()
         self.monitor.kv('callback_duration', duration)
         self.monitor.count('accumulated_callback_duration', duration)

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -31,4 +31,3 @@ class UtilizationCollector(object):
 
     def stop(self):
         self.monitor.add_callback = self.original_add_callback
-        self.flush_callback.stop()

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -1,8 +1,36 @@
 import time
+from functools import wraps
 
 
 class UtilizationCollector(object):
+    """Collects stats for overall callback durations"""
 
+    def __init__(self, monitor):
+        self.monitor = monitor
+
+    def start(self):
+        self.original_add_callback = self.monitor.io_loop.add_callback
+        utilization_stat = ExecutionTimer(self.monitor)
+
+        def measure_callback(callback):
+            @wraps(callback)
+            def timed_callback(*args, **kwargs):
+                with utilization_stat:
+                    return callback(*args, **kwargs)
+
+            return timed_callback
+
+        @wraps(self.original_add_callback)
+        def add_timed_callback(callback, *args, **kwargs):
+            return self.original_add_callback(measure_callback(callback), *args, **kwargs)
+
+        self.monitor.io_loop.add_callback = add_timed_callback
+
+    def stop(self):
+        self.monitor.add_callback = self.original_add_callback
+
+
+class ExecutionTimer(object):
     def __init__(self, monitor):
         self.last_start_time = time.time()
         self.monitor = monitor

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -9,7 +9,7 @@ class UtilizationCollector(object):
 
     def __init__(self, monitor, flush_interval):
         self.monitor = monitor
-        self.flush_interval = flush_interval
+        self.flush_interval = flush_interval or 10000
         self._clear()
 
     def start(self):

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -1,8 +1,6 @@
 import time
 from functools import wraps
 
-import tornado
-
 
 class UtilizationCollector(object):
     """Collects stats for overall callback durations"""
@@ -10,7 +8,6 @@ class UtilizationCollector(object):
     def __init__(self, monitor, flush_interval):
         self.monitor = monitor
         self.flush_interval = flush_interval or 10000
-        self._clear()
 
     def start(self):
         self.original_add_callback = self.monitor.io_loop.add_callback
@@ -18,14 +15,10 @@ class UtilizationCollector(object):
         def measure_callback(callback):
             @wraps(callback)
             def timed_callback(*args, **kwargs):
-                self.last_start_time = time.time()
-                now = time.time()
-                self.last_start_time = now
+                last_start_time = time.time()
                 result = callback(*args, **kwargs)
-                duration = (time.time() - self.last_start_time)
-                self.last_start_time = time.time()
-                self.total_duration += duration
-                self.callbacks += 1
+                duration = (time.time() - last_start_time)
+                self.monitor.accumulated_kv('callback_duration', duration)
 
                 return result
 
@@ -37,21 +30,6 @@ class UtilizationCollector(object):
 
         self.monitor.io_loop.add_callback = add_timed_callback
 
-        self.flush_callback = tornado.ioloop.PeriodicCallback(
-            lambda: self._flush(),
-            self.flush_interval,
-            self.monitor.io_loop,
-        )
-
     def stop(self):
         self.monitor.add_callback = self.original_add_callback
         self.flush_callback.stop()
-        self._flush()
-
-    def _flush(self):
-        self.monitor.kv('callback_duration', self.total_duration)
-        self.clear()
-
-    def _clear(self):
-        self.total_duration = 0
-        self.callbacks = 0

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -1,0 +1,18 @@
+import time
+
+
+class UtilizationCollector(object):
+
+    def __init__(self, monitor):
+        self.last_time = time.time()
+        self.monitor = monitor
+
+    def __enter__(self):
+        now = time.time()
+        self.last_time = now
+
+    def __exit__(self, *args, **kwargs):
+        duration = (time.time() - self.last_time)
+        self.last_time = time.time()
+        self.monitor.kv('callback_duration', duration)
+        self.monitor.count('accumulated_callback_duration', duration)

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from functools import wraps
 
 from tornado.ioloop import IOLoop
 
@@ -32,12 +33,14 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
     utilization_stat = UtilizationCollector(monitor)
 
     def measure_callback(callback):
+        @wraps(callback)
         def timed_callback(*args, **kwargs):
             with utilization_stat:
                 return callback(*args, **kwargs)
 
         return timed_callback
 
+    @wraps(add_callback)
     def add_timed_callback(callback, *args, **kwargs):
         return add_callback(measure_callback(callback), *args, **kwargs)
 

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -30,7 +30,7 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
         web_collector = WebCollector(monitor, tornado_app)
         web_collector.start()
 
-    utilization_collector = UtilizationCollector(monitor, publish_interval)
+    utilization_collector = UtilizationCollector(monitor)
     utilization_collector.start()
 
     return monitor

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -28,16 +28,20 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
     monitor.start()
 
     ioloop = IOLoop.current()
-    run_callback = ioloop.run_callback
+    add_callback = ioloop.add_callback
     utilization_stat = UtilizationCollector(monitor)
 
-    def timed_run_calback(*args, **kwargs):
-        global stat
+    def measure_callback(callback):
+        def timed_callback(*args, **kwargs):
+            with utilization_stat:
+                return callback(*args, **kwargs)
 
-        with utilization_stat:
-            return run_callback(*args, **kwargs)
+        return timed_callback
 
-    ioloop.run_callback = timed_run_calback
+    def add_timed_callback(callback, *args, **kwargs):
+        return add_callback(measure_callback(callback), *args, **kwargs)
+
+    ioloop.add_callback = add_timed_callback
 
     if tornado_app:
         web_collector = WebCollector(monitor, tornado_app)

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -30,7 +30,7 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
         web_collector = WebCollector(monitor, tornado_app)
         web_collector.start()
 
-    utilization_collector = UtilizationCollector(monitor)
+    utilization_collector = UtilizationCollector(monitor, publish_interval)
     utilization_collector.start()
 
     return monitor

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import
 
+from tornado.ioloop import IOLoop
+
 from mutornadomon import MuTornadoMon
 from mutornadomon.external_interfaces.publish import PublishExternalInterface
 from mutornadomon.external_interfaces.http_endpoints import HTTPEndpointExternalInterface
 from mutornadomon.collectors.web import WebCollector
+from mutornadomon.collectors.ioloop_util import UtilizationCollector
 
 
 def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=None,
@@ -23,6 +26,18 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
     # Start collecting metrics and register endpoint with app
     monitor = MuTornadoMon(external_interface, **monitor_config)
     monitor.start()
+
+    ioloop = IOLoop.current()
+    run_callback = ioloop.run_callback
+    utilization_stat = UtilizationCollector(monitor)
+
+    def timed_run_calback(*args, **kwargs):
+        global stat
+
+        with utilization_stat:
+            return run_callback(*args, **kwargs)
+
+    ioloop.run_callback = timed_run_calback
 
     if tornado_app:
         web_collector = WebCollector(monitor, tornado_app)

--- a/mutornadomon/monitor.py
+++ b/mutornadomon/monitor.py
@@ -88,6 +88,7 @@ class MuTornadoMon(object):
         """
         self._MIN_GAUGES = {}
         self._MAX_GAUGES = {}
+        self._ACCUMULATED_GAUGES = collections.defaultdict(float)
 
     def count(self, stat, value=1):
         """Increment a counter by the given value"""
@@ -104,6 +105,11 @@ class MuTornadoMon(object):
             self._MAX_GAUGES[stat] = value
         if stat not in self._MIN_GAUGES or value < self._MIN_GAUGES[stat]:
             self._MIN_GAUGES[stat] = value
+
+    def accumulated_kv(self, stat, value):
+        """Accumulate a value that will be flushed to a gauge when metrics is read"""
+
+        self._ACCUMULATED_GAUGES[stat] += value
 
     def start(self):
         for collector in self.collectors:
@@ -154,6 +160,8 @@ class MuTornadoMon(object):
             create_time = me.create_time()
             num_threads = me.num_threads()
             num_fds = me.num_fds()
+        for key, value in self._ACCUMULATED_GAUGES.iteritems():
+            self.kv(key, value)
         rv = {
             'process': {
                 'uptime': time.time() - create_time,

--- a/mutornadomon/monitor.py
+++ b/mutornadomon/monitor.py
@@ -160,7 +160,7 @@ class MuTornadoMon(object):
             create_time = me.create_time()
             num_threads = me.num_threads()
             num_fds = me.num_fds()
-        for key, value in self._ACCUMULATED_GAUGES.iteritems():
+        for key, value in self._ACCUMULATED_GAUGES.items():
             self.kv(key, value)
         rv = {
             'process': {

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,10 +36,11 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
         resp = self.fetch('/mutornadomon')
         self.assertEqual(resp.code, 200)
         resp = json.loads(resp.body.decode('utf-8'))
-        self.assertEqual(
-            resp['counters'],
-            {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}
+        self.assertDictContainsSubset(
+            {'requests': 2, 'localhost_requests': 2, 'private_requests': 2},
+            resp['counters']
         )
+        self.assertIn('accumulated_callback_duration', resp['counters'])
         self.assertEqual(resp['process']['cpu']['num_threads'], 5)
         assert resp['process']['cpu']['system_time'] < 1.0
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,11 +36,9 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
         resp = self.fetch('/mutornadomon')
         self.assertEqual(resp.code, 200)
         resp = json.loads(resp.body.decode('utf-8'))
-        self.assertDictContainsSubset(
-            {'requests': 2, 'localhost_requests': 2, 'private_requests': 2},
-            resp['counters']
-        )
-        self.assertIn('accumulated_callback_duration', resp['counters'])
+        expected = {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}.items()
+        self.assertTrue(all(pair in resp['counters'].items() for pair in expected))
+        self.assertTrue('accumulated_callback_duration' in resp['counters'])
         self.assertEqual(resp['process']['cpu']['num_threads'], 5)
         assert resp['process']['cpu']['system_time'] < 1.0
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -38,7 +38,6 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
         resp = json.loads(resp.body.decode('utf-8'))
         expected = {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}.items()
         self.assertTrue(all(pair in resp['counters'].items() for pair in expected))
-        self.assertTrue('accumulated_callback_duration' in resp['counters'])
         self.assertEqual(resp['process']['cpu']['num_threads'], 5)
         assert resp['process']['cpu']['system_time'] < 1.0
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
         mutornadomon_mock.assert_called_once()
         web_collector_mock.assert_called_once_with(monitor_inst, app)
-        utilization_collector_mock.assert_called_once_with(monitor_inst, None)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         # MuTornadoMon was created with monitor config values
         arg_list = mutornadomon_mock.call_args_list
@@ -63,7 +63,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEqual(result, monitor_inst)
 
         web_collector_mock.assert_called_once_with(monitor_inst, app)
-        utilization_collector_mock.assert_called_once_with(monitor_inst, None)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         mutornadomon_mock.assert_called_once()
         arg_list = mutornadomon_mock.call_args_list

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,8 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
     @mock.patch('mutornadomon.config.MuTornadoMon')
     @mock.patch('mutornadomon.config.WebCollector')
-    def test_initialize_mutornadmon(self, web_collector_mock, mutornadomon_mock):
+    @mock.patch('mutornadomon.config.UtilizationCollector')
+    def test_initialize_mutornadmon(self, utilization_collector_mock, web_collector_mock, mutornadomon_mock):
         """Test initialize_mutornadomon() sets up HTTP endpoints interface"""
         app = sentinel.application,
         result = initialize_mutornadomon(app, host_limit='test')
@@ -26,6 +27,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
         mutornadomon_mock.assert_called_once()
         web_collector_mock.assert_called_once_with(monitor_inst, app)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         # MuTornadoMon was created with monitor config values
         arg_list = mutornadomon_mock.call_args_list
@@ -39,7 +41,13 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
     @mock.patch('mutornadomon.config.MuTornadoMon')
     @mock.patch('mutornadomon.config.WebCollector')
-    def test_initialize_mutornadmon_passes_publisher(self, web_collector_mock, mutornadomon_mock):
+    @mock.patch('mutornadomon.config.UtilizationCollector')
+    def test_initialize_mutornadmon_passes_publisher(
+        self,
+        utilization_collector_mock,
+        web_collector_mock,
+        mutornadomon_mock
+    ):
         """Test initialize_mutornadomon() sets up publishing interface"""
 
         def publisher(monitor):
@@ -55,6 +63,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEqual(result, monitor_inst)
 
         web_collector_mock.assert_called_once_with(monitor_inst, app)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         mutornadomon_mock.assert_called_once()
         arg_list = mutornadomon_mock.call_args_list
@@ -72,8 +81,9 @@ class TestInitializeMutornadomon(unittest.TestCase):
         def publisher(monitor):
             pass
 
-        result = initialize_mutornadomon(publisher=publisher)
         monitor_inst = mutornadomon_mock.return_value
+        monitor_inst.io_loop.add_callback.__name__ = 'add_callback'
+        result = initialize_mutornadomon(publisher=publisher)
 
         # initialize_mutornadomon() should return the monitor instance
         self.assertEqual(result, monitor_inst)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
         mutornadomon_mock.assert_called_once()
         web_collector_mock.assert_called_once_with(monitor_inst, app)
-        utilization_collector_mock.assert_called_once_with(monitor_inst)
+        utilization_collector_mock.assert_called_once_with(monitor_inst, None)
 
         # MuTornadoMon was created with monitor config values
         arg_list = mutornadomon_mock.call_args_list
@@ -63,7 +63,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEqual(result, monitor_inst)
 
         web_collector_mock.assert_called_once_with(monitor_inst, app)
-        utilization_collector_mock.assert_called_once_with(monitor_inst)
+        utilization_collector_mock.assert_called_once_with(monitor_inst, None)
 
         mutornadomon_mock.assert_called_once()
         arg_list = mutornadomon_mock.call_args_list


### PR DESCRIPTION
This will provide a metric showing the time spent in processing of callbacks vs. total runtime.
This is intended to be used as an IOLoop utilization metric.