### PR TITLE
Reintroduce the ioloop utilization without wraps

### DIFF
--- a/mutornadomon/__init__.py
+++ b/mutornadomon/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .monitor import MuTornadoMon  # noqa
 from .config import initialize_mutornadomon  # noqa
 
-version_info = (0, 3, 1)
+version_info = (0, 3, 2)
 __name__ = 'MuTornadoMon'
 __author__ = 'jbrown@uber.com'
 __version__ = '.'.join(map(str, version_info))

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -15,7 +15,7 @@ class UtilizationCollector(object):
             last_start_time = time.time()
             result = self.original_run_callback(callback)
             duration = (time.time() - last_start_time)
-            self.monitor.kv('callback_duration', duration)
+            self.monitor.count('callback_duration', duration)
 
             return result
 
@@ -24,7 +24,7 @@ class UtilizationCollector(object):
                 start_time = time.time()
                 result = handler(*args, **kwargs)
                 duration = (time.time() - start_time)
-                self.monitor.kv('callback_duration', duration)
+                self.monitor.count('callback_duration', duration)
 
                 return result
 

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -15,7 +15,7 @@ class UtilizationCollector(object):
                 last_start_time = time.time()
                 result = callback(*args, **kwargs)
                 duration = (time.time() - last_start_time)
-                self.monitor.accumulated_kv('callback_duration', duration)
+                self.monitor.kv('callback_duration', duration)
 
                 return result
 

--- a/mutornadomon/collectors/ioloop_util.py
+++ b/mutornadomon/collectors/ioloop_util.py
@@ -1,0 +1,30 @@
+import time
+
+
+class UtilizationCollector(object):
+    """Collects stats for overall callback durations"""
+
+    def __init__(self, monitor):
+        self.monitor = monitor
+
+    def start(self):
+        self.original_add_callback = self.monitor.io_loop.add_callback
+
+        def measure_callback(callback):
+            def timed_callback(*args, **kwargs):
+                last_start_time = time.time()
+                result = callback(*args, **kwargs)
+                duration = (time.time() - last_start_time)
+                self.monitor.accumulated_kv('callback_duration', duration)
+
+                return result
+
+            return timed_callback
+
+        def add_timed_callback(callback, *args, **kwargs):
+            return self.original_add_callback(measure_callback(callback), *args, **kwargs)
+
+        self.monitor.io_loop.add_callback = add_timed_callback
+
+    def stop(self):
+        self.monitor.add_callback = self.original_add_callback

--- a/mutornadomon/config.py
+++ b/mutornadomon/config.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
+
 from mutornadomon import MuTornadoMon
 from mutornadomon.external_interfaces.publish import PublishExternalInterface
 from mutornadomon.external_interfaces.http_endpoints import HTTPEndpointExternalInterface
 from mutornadomon.collectors.web import WebCollector
+from mutornadomon.collectors.ioloop_util import UtilizationCollector
 
 
 def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=None,
@@ -27,5 +29,8 @@ def initialize_mutornadomon(tornado_app=None, publisher=None, publish_interval=N
     if tornado_app:
         web_collector = WebCollector(monitor, tornado_app)
         web_collector.start()
+
+    utilization_collector = UtilizationCollector(monitor)
+    utilization_collector.start()
 
     return monitor

--- a/mutornadomon/monitor.py
+++ b/mutornadomon/monitor.py
@@ -88,7 +88,6 @@ class MuTornadoMon(object):
         """
         self._MIN_GAUGES = {}
         self._MAX_GAUGES = {}
-        self._ACCUMULATED_GAUGES = collections.defaultdict(float)
 
     def count(self, stat, value=1):
         """Increment a counter by the given value"""
@@ -105,11 +104,6 @@ class MuTornadoMon(object):
             self._MAX_GAUGES[stat] = value
         if stat not in self._MIN_GAUGES or value < self._MIN_GAUGES[stat]:
             self._MIN_GAUGES[stat] = value
-
-    def accumulated_kv(self, stat, value):
-        """Accumulate a value that will be flushed to a gauge when metrics is read"""
-
-        self._ACCUMULATED_GAUGES[stat] += value
 
     def start(self):
         for collector in self.collectors:
@@ -160,8 +154,6 @@ class MuTornadoMon(object):
             create_time = me.create_time()
             num_threads = me.num_threads()
             num_fds = me.num_fds()
-        for key, value in self._ACCUMULATED_GAUGES.items():
-            self.kv(key, value)
         rv = {
             'process': {
                 'uptime': time.time() - create_time,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read_long_description(filename="README.md"):
 
 setup(
     name="mutornadomon",
-    version="0.3.1",
+    version="0.3.2",
     author="James Brown",
     author_email="jbrown@uber.com",
     url="https://github.com/uber/mutornadomon",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,10 +36,8 @@ class TestBasic(tornado.testing.AsyncHTTPTestCase):
         resp = self.fetch('/mutornadomon')
         self.assertEqual(resp.code, 200)
         resp = json.loads(resp.body.decode('utf-8'))
-        self.assertEqual(
-            resp['counters'],
-            {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}
-        )
+        expected = {'requests': 2, 'localhost_requests': 2, 'private_requests': 2}.items()
+        self.assertTrue(all(pair in resp['counters'].items() for pair in expected))
         self.assertEqual(resp['process']['cpu']['num_threads'], 5)
         assert resp['process']['cpu']['system_time'] < 1.0
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,8 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
     @mock.patch('mutornadomon.config.MuTornadoMon')
     @mock.patch('mutornadomon.config.WebCollector')
-    def test_initialize_mutornadmon(self, web_collector_mock, mutornadomon_mock):
+    @mock.patch('mutornadomon.config.UtilizationCollector')
+    def test_initialize_mutornadmon(self, utilization_collector_mock, web_collector_mock, mutornadomon_mock):
         """Test initialize_mutornadomon() sets up HTTP endpoints interface"""
         app = sentinel.application,
         result = initialize_mutornadomon(app, host_limit='test')
@@ -26,6 +27,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
         mutornadomon_mock.assert_called_once()
         web_collector_mock.assert_called_once_with(monitor_inst, app)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         # MuTornadoMon was created with monitor config values
         arg_list = mutornadomon_mock.call_args_list
@@ -39,7 +41,13 @@ class TestInitializeMutornadomon(unittest.TestCase):
 
     @mock.patch('mutornadomon.config.MuTornadoMon')
     @mock.patch('mutornadomon.config.WebCollector')
-    def test_initialize_mutornadmon_passes_publisher(self, web_collector_mock, mutornadomon_mock):
+    @mock.patch('mutornadomon.config.UtilizationCollector')
+    def test_initialize_mutornadmon_passes_publisher(
+        self,
+        utilization_collector_mock,
+        web_collector_mock,
+        mutornadomon_mock
+    ):
         """Test initialize_mutornadomon() sets up publishing interface"""
 
         def publisher(monitor):
@@ -55,6 +63,7 @@ class TestInitializeMutornadomon(unittest.TestCase):
         self.assertEqual(result, monitor_inst)
 
         web_collector_mock.assert_called_once_with(monitor_inst, app)
+        utilization_collector_mock.assert_called_once_with(monitor_inst)
 
         mutornadomon_mock.assert_called_once()
         arg_list = mutornadomon_mock.call_args_list
@@ -72,8 +81,8 @@ class TestInitializeMutornadomon(unittest.TestCase):
         def publisher(monitor):
             pass
 
-        result = initialize_mutornadomon(publisher=publisher)
         monitor_inst = mutornadomon_mock.return_value
+        result = initialize_mutornadomon(publisher=publisher)
 
         # initialize_mutornadomon() should return the monitor instance
         self.assertEqual(result, monitor_inst)


### PR DESCRIPTION
This introduces the ioloop utilization metric again, but does not use `functools.wraps` which broke with things liek partials and other callables that aren't normal functions.