### PR TITLE
pass ips as character strings

### DIFF
--- a/mutornadomon/net.py
+++ b/mutornadomon/net.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 try:
     import ipaddress
     Network = ipaddress.ip_network


### PR DESCRIPTION
These are failing with "ValueError: '10.0.0.0/8' does not appear to be an IPv4 or IPv6 network". https://github.com/phihag/ipaddress/issues/5

@abhinav @emou @kunev 