### PR TITLE
Convert string to unicodes for Python2

### DIFF
--- a/mutornadomon/net.py
+++ b/mutornadomon/net.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import six
+
 try:
     import ipaddress
     Network = ipaddress.ip_network
@@ -44,7 +46,6 @@ def is_private_address(ip):
 
 def _convert_to_unicode(ip):
     """Converts given ip to unicode if its str type for python2."""
-    import six
     if six.PY2 and type(ip) == str:
         return six.u(ip)
     return ip

--- a/mutornadomon/net.py
+++ b/mutornadomon/net.py
@@ -31,10 +31,20 @@ LOCAL_NETS = [
 
 
 def is_local_address(ip):
+    ip = _convert_to_unicode(ip)
     ip = IP(ip)
     return any(ip in net for net in LOCAL_NETS)
 
 
 def is_private_address(ip):
+    ip = _convert_to_unicode(ip)
     ip = IP(ip)
     return any(ip in net for net in PRIVATE_NETS)
+
+
+def _convert_to_unicode(ip):
+    """Converts given ip to unicode if its str type for python2."""
+    import six
+    if six.PY2 and type(ip) == str:
+        return six.u(ip)
+    return ip

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read_long_description(filename="README.md"):
 
 setup(
     name="mutornadomon",
-    version="0.4.0",
+    version="0.4.1",
     author="Uber Technologies, Inc.",
     author_email="dev@uber.com",
     url="https://github.com/uber/mutornadomon",

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import
+
+import mock
+import unittest
+
+from mutornadomon.net import is_local_address
+from mutornadomon.net import is_private_address
+
+
+class TestIsLocalAddress(unittest.TestCase):
+
+    @mock.patch('six.PY2')
+    def test_is_local_address_works_with_python2(self, is_python2_mock):
+        """Test is_local_address method works for python2."""
+        is_python2_mock.return_value = True
+        self.assertTrue(is_local_address(b'127.0.0.1'))
+        self.assertTrue(is_local_address(u'127.0.0.1'))
+        self.assertTrue(is_local_address('127.0.0.1'))
+        self.assertFalse(is_local_address('126.0.0.10'))
+
+    @mock.patch('six.PY2')
+    def test_is_local_address_works_with_python3(self, is_python2_mock):
+        """Test is_local_address method works for python3."""
+        is_python2_mock.return_value = False
+        self.assertTrue(is_local_address(b'127.0.0.1'))
+        self.assertTrue(is_local_address(u'127.0.0.1'))
+        self.assertTrue(is_local_address('127.0.0.1'))
+        self.assertFalse(is_local_address('126.0.0.10'))
+
+
+class TestIsPrivateAddress(unittest.TestCase):
+
+    @mock.patch('six.PY2')
+    def test_is_private_address_works_with_python2(self, is_python2_mock):
+        """Test is_private_address method works for python2."""
+        is_python2_mock.return_value = True
+        self.assertTrue(is_private_address(b'127.0.0.1'))
+        self.assertTrue(is_private_address(u'127.0.0.1'))
+        self.assertTrue(is_private_address('127.0.0.1'))
+        self.assertFalse(is_private_address('126.0.0.10'))
+
+    @mock.patch('six.PY2')
+    def test_is_private_address_works_with_python3(self, is_python2_mock):
+        """Test is_private_address method works for python3."""
+        is_python2_mock.return_value = False
+        self.assertTrue(is_private_address(b'127.0.0.1'))
+        self.assertTrue(is_private_address(u'127.0.0.1'))
+        self.assertTrue(is_private_address('127.0.0.1'))
+        self.assertFalse(is_private_address('126.0.0.10'))

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -13,7 +13,6 @@ class TestIsLocalAddress(unittest.TestCase):
     def test_is_local_address_works_with_python2(self, is_python2_mock):
         """Test is_local_address method works for python2."""
         is_python2_mock.return_value = True
-        self.assertTrue(is_local_address(b'127.0.0.1'))
         self.assertTrue(is_local_address(u'127.0.0.1'))
         self.assertTrue(is_local_address('127.0.0.1'))
         self.assertFalse(is_local_address('126.0.0.10'))
@@ -22,7 +21,6 @@ class TestIsLocalAddress(unittest.TestCase):
     def test_is_local_address_works_with_python3(self, is_python2_mock):
         """Test is_local_address method works for python3."""
         is_python2_mock.return_value = False
-        self.assertTrue(is_local_address(b'127.0.0.1'))
         self.assertTrue(is_local_address(u'127.0.0.1'))
         self.assertTrue(is_local_address('127.0.0.1'))
         self.assertFalse(is_local_address('126.0.0.10'))
@@ -34,7 +32,6 @@ class TestIsPrivateAddress(unittest.TestCase):
     def test_is_private_address_works_with_python2(self, is_python2_mock):
         """Test is_private_address method works for python2."""
         is_python2_mock.return_value = True
-        self.assertTrue(is_private_address(b'127.0.0.1'))
         self.assertTrue(is_private_address(u'127.0.0.1'))
         self.assertTrue(is_private_address('127.0.0.1'))
         self.assertFalse(is_private_address('126.0.0.10'))
@@ -43,7 +40,6 @@ class TestIsPrivateAddress(unittest.TestCase):
     def test_is_private_address_works_with_python3(self, is_python2_mock):
         """Test is_private_address method works for python3."""
         is_python2_mock.return_value = False
-        self.assertTrue(is_private_address(b'127.0.0.1'))
         self.assertTrue(is_private_address(u'127.0.0.1'))
         self.assertTrue(is_private_address('127.0.0.1'))
         self.assertFalse(is_private_address('126.0.0.10'))


### PR DESCRIPTION
https://github.com/uber/mutornadomon/pull/15 fixed the net.py module but if the methods is_local_address and is_private_address are called with strings, they still fail if the project has ipaddress included. 
This will make sure the unicode strings are actually used for passing to ipaddress.ip_address methods. 