### PR TITLE
Fix description issue causing package to be unable to be installed on Py3+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (3, 0):
 
 
 def read_long_description(filename="README.md"):
-    with open(filename) as f:
+    with open(filename, "r", encoding="utf-8") as f:
         return f.read().strip()
 
 


### PR DESCRIPTION
- README.md file is read as description & now its encoded during read to fix the issue while reading special characters.