### PR TITLE
fix: type error prevention while importing

### DIFF
--- a/mutornadomon/__init__.py
+++ b/mutornadomon/__init__.py
@@ -9,4 +9,4 @@ __author__ = 'dev@uber.com'
 __version__ = '.'.join(map(str, version_info))
 __license__ = 'MIT'
 
-__all__ = ['MuTornadoMon', initialize_mutornadomon, 'version_info']
+__all__ = ['MuTornadoMon', 'initialize_mutornadomon', 'version_info']


### PR DESCRIPTION
In file: `__init__.py`, the list named (`__all__`) contains unquoted names which can result in errors/exceptions(TypeError) when this module is imported. The names should be inside quote but they are not. This PR suggests that fix.

##### Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.